### PR TITLE
Retrieve badges from workflow runs on develop branch.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # ghcr.io Container Repository Cleanup Action
 
-[![GitHub Super-Linter](https://github.com/jenskeiner/ghcr-container-repository-cleanup-action/actions/workflows/linter.yml/badge.svg)](https://github.com/super-linter/super-linter)
-![CI](https://github.com/jenskeiner/ghcr-container-repository-cleanup-action/actions/workflows/ci.yml/badge.svg)
-[![Check dist/](https://github.com/jenskeiner/ghcr-container-repository-cleanup-action/actions/workflows/check-dist.yml/badge.svg)](https://github.com/jenskeiner/ghcr-container-repository-cleanup-action/actions/workflows/check-dist.yml)
-[![CodeQL](https://github.com/jenskeiner/ghcr-container-repository-cleanup-action/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/jenskeiner/ghcr-container-repository-cleanup-action/actions/workflows/codeql-analysis.yml)
+[![GitHub Super-Linter](https://github.com/jenskeiner/ghcr-container-repository-cleanup-action/actions/workflows/linter.yml/badge.svg?branch=develop)](https://github.com/super-linter/super-linter)
+![CI](https://github.com/jenskeiner/ghcr-container-repository-cleanup-action/actions/workflows/ci.yml/badge.svg?branch=develop)
+[![Check dist/](https://github.com/jenskeiner/ghcr-container-repository-cleanup-action/actions/workflows/check-dist.yml/badge.svg?branch=develop)](https://github.com/jenskeiner/ghcr-container-repository-cleanup-action/actions/workflows/check-dist.yml)
+[![CodeQL](https://github.com/jenskeiner/ghcr-container-repository-cleanup-action/actions/workflows/codeql-analysis.yml/badge.svg?branch=develop)](https://github.com/jenskeiner/ghcr-container-repository-cleanup-action/actions/workflows/codeql-analysis.yml)
 [![Coverage](./badges/coverage.svg)](./badges/coverage.svg)
 
 A workflow action that deletes obsolete tags and versions from a GitHub


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Update the README.md file to ensure that workflow badges are retrieved from the 'develop' branch, providing more accurate status indicators for ongoing development work.

Documentation:
- Update README.md to retrieve workflow badges from the 'develop' branch instead of the default branch.

<!-- Generated by sourcery-ai[bot]: end summary -->