### PR TITLE
Adjust workflow triggers.

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -11,18 +11,12 @@ name: autofix.ci
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, reopened, synchronize]
     branches:
       - develop
   push:
     branches:
-      - main
       - develop
-      - 'feature/**'
-      - 'bugfix/**'
-      - 'release/**'
-      - 'hotfix/**'
-      - 'support/**'
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,13 @@
 name: Integration Tests
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, reopened, synchronize]
     branches:
-      - develop
+      - main
   push:
     branches:
-      - develop
+      - main
   schedule:
     - cron: '31 7 * * 3'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,15 @@
 name: Integration Tests
 
 on:
-  workflow_dispatch: {}
+  pull_request:
+    types: [opened, reopened, synchronize]
+    branches:
+      - develop
   push:
-  pull_request_target:
-    types: [assigned, opened, synchronize, reopened]
+    branches:
+      - develop
+  schedule:
+    - cron: '31 7 * * 3'
 
 permissions:
   id-token: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: Integration Tests
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, reopened, synchronize]
     branches:
       - main

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,7 +1,8 @@
 name: CodeQL
 
 on:
-  pull_request:
+  pull_request_target:
+    types: [opened, reopened, synchronize]
     branches:
       - main
   push:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,7 +1,7 @@
 name: CodeQL
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, reopened, synchronize]
     branches:
       - main

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,7 +1,7 @@
 name: Lint Codebase
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, reopened, synchronize]
     branches:
       - main

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,6 +1,15 @@
 name: Lint Codebase
 
-on: [pull_request, push]
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+    branches:
+      - develop
+  push:
+    branches:
+      - develop
+  schedule:
+    - cron: '31 7 * * 3'
 
 permissions:
   contents: read

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,13 +1,13 @@
 name: Lint Codebase
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, reopened, synchronize]
     branches:
-      - develop
+      - main
   push:
     branches:
-      - develop
+      - main
   schedule:
     - cron: '31 7 * * 3'
 


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Update CI workflow triggers to focus on the 'develop' branch and introduce a weekly schedule for running integration tests and linting.

CI:
- Adjust workflow triggers to run on pull requests and pushes to the 'develop' branch, and schedule them to run weekly on Wednesdays at 07:31 UTC.

<!-- Generated by sourcery-ai[bot]: end summary -->