### PR TITLE
Fix trigger.

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -10,13 +10,13 @@
 name: autofix.ci
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, reopened, synchronize]
     branches:
-      - develop
+      - main
   push:
     branches:
-      - develop
+      - main
 
 permissions:
   contents: read


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Update the GitHub Actions workflow to trigger on 'pull_request_target' events and change the branch references from 'develop' to 'main'.

CI:
- Change the GitHub Actions workflow trigger from 'pull_request' to 'pull_request_target'.
- Update the branches for triggering the workflow from 'develop' to 'main' for both pull request and push events.

<!-- Generated by sourcery-ai[bot]: end summary -->